### PR TITLE
Guard against bad OmeroRequest arguments

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/core/OmeroRequest.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/core/OmeroRequest.java
@@ -75,6 +75,14 @@ public class OmeroRequest implements Closeable {
                 ServerError {
         log.debug("Connecting to the server: {}, {}, {}",
                 host, port, omeroSessionKey);
+        // Guard against bad input that may cause us big problems later
+        if (host == null || port < 1) {
+            throw new IllegalArgumentException(
+                    "Misconfigured OMERO server host and/or port");
+        }
+        if (omeroSessionKey == null) {
+            throw new PermissionDeniedException("Missing OMERO session key!");
+        }
         this.omeroSessionKey = omeroSessionKey;
         this.client = new omero.client(host, port);
         Tracer tracer = Tracing.currentTracer();


### PR DESCRIPTION
In some circumstances bad input could be provided to OmeroRequest instances which can cause ugly downstream effects (in particular with the tracing system). This PR guards against those.

/cc @stick 