### PR TITLE
CI: upload build archives as artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,3 +30,8 @@ jobs:
         if: github.event_name != 'pull_request' && matrix.java == 11
         run: |
           ./gradlew -PArtifactoryUserName=${ArtifactoryUserName} -PArtifactoryPassword=${ArtifactoryPassword} publish
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: omero-ms-core ${{ matrix.java }}
+          path: build/libs/*


### PR DESCRIPTION
As discussed with @kkoz, this will upload the JAR generated from Gradle build as artifacts of the GitHub run allowing reviewers to easily download it and consume it in their local micro-service distribution for functional review