### PR TITLE
OmeroRequestCtx: add utility methods for parameters parsing

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/core/OmeroRequestCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/core/OmeroRequestCtx.java
@@ -21,6 +21,8 @@ package com.glencoesoftware.omero.ms.core;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.vertx.core.MultiMap;
+
 import brave.Tracing;
 import brave.propagation.Propagation.Setter;
 import brave.propagation.TraceContext.Injector;
@@ -59,5 +61,71 @@ public abstract class OmeroRequestCtx {
                 tracing.propagation().injector(SETTER);
         injector.inject(
                 Tracing.currentTracer().currentSpan().context(), traceContext);
+    }
+
+    /**
+     * Return the key of a multi-map
+     * @param params a multi-map object
+     * @param key the key to return
+     * @return true if the key exists and has a value equal to true, false otherwise
+     */
+    public static String getCheckedParam(MultiMap params, String key)
+        throws IllegalArgumentException {
+        String value = params.get(key);
+        if (null == value) {
+            throw new IllegalArgumentException("Missing parameter '"
+                + key + "'");
+        }
+        return value;
+    }
+
+    /**
+     * Return a key as a boolean from a multimap
+     * @param params a MultiMap object
+     * @param key a String specifying the key
+     * @return true if the key exists and has a value equal to true, false otherwise
+     */
+    public static Boolean getBooleanParameter(MultiMap params, String key) {
+        if (params.get(key) != null) {
+            String booleanString = params.get(key).toLowerCase();
+            if (booleanString.equals("true")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Parse a string value as a Long object
+     * @param imageIdString a value representing an image ID
+     * @return the image ID as an Long object
+     * @throw an IllegalArgumentException if the string cannot be parsed as a Long
+     */
+    public static Long getImageIdFromString(String imageIdString)
+        throws IllegalArgumentException{
+        try {
+            return Long.parseLong(imageIdString);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Incorrect format for "
+                + "imageId parameter '" + imageIdString + "'");
+        }
+    }
+
+    /**
+     * Parse a string value as an Integer and return it
+     * @param intString a value representing an integer
+     * @return the value parsed as an Integer object
+     * @throw an IllegalArgumentException if the string cannot be parsed as an integer
+     */
+    public static Integer getIntegerFromString(String intString)
+        throws IllegalArgumentException{
+        Integer i = null;
+        try {
+            i = Integer.parseInt(intString);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Incorrect format for "
+                + "parameter value '" + intString + "'");
+        }
+        return i;
     }
 }

--- a/src/main/java/com/glencoesoftware/omero/ms/core/OmeroRequestCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/core/OmeroRequestCtx.java
@@ -96,19 +96,26 @@ public abstract class OmeroRequestCtx {
     }
 
     /**
-     * Parse a string value as a Long object
+     * Parse a string value as a valid image ID
      * @param imageIdString a value representing an image ID
-     * @return the image ID as an Long object
+     * @return the image ID as a Long
      * @throw an IllegalArgumentException if the string cannot be parsed as a Long
+     * or if the parsed Long is not positive
      */
     public static Long getImageIdFromString(String imageIdString)
         throws IllegalArgumentException{
+        Long imageId;
         try {
-            return Long.parseLong(imageIdString);
+            imageId = Long.parseLong(imageIdString);
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Incorrect format for "
                 + "imageId parameter '" + imageIdString + "'");
         }
+        if (imageId <= 0) {
+            throw new IllegalArgumentException("Incorrect format for "
+                + "imageId parameter '" + imageIdString + "'");
+        }
+        return imageId;
     }
 
     /**

--- a/src/test/java/com/glencoesoftware/omero/ms/core/OmeroRequestCtxTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/core/OmeroRequestCtxTest.java
@@ -78,32 +78,32 @@ public class OmeroRequestCtxTest {
         Assert.assertTrue(OmeroRequestCtx.getBooleanParameter(params, "boolean1"));
     }
 
-    @DataProvider(name = "valid longs")
+    @DataProvider(name = "valid image IDs")
     public Object[][] validLongs() {
         return new Object[][] {
-            {"0", Long.valueOf(0)},
             {"1", Long.valueOf(1)},
             {String.valueOf(Integer.MAX_VALUE), Long.valueOf(Integer.MAX_VALUE)},
-            {String.valueOf(-Integer.MAX_VALUE), Long.valueOf(-Integer.MAX_VALUE)},
             {String.valueOf(Long.MAX_VALUE), Long.valueOf(Long.MAX_VALUE)}
         };
     }
 
-    @Test(dataProvider = "valid longs")
+    @Test(dataProvider = "valid image IDs")
     public void testGetImageIdFromString(String value, Long id) {
         Assert.assertEquals(OmeroRequestCtx.getImageIdFromString(value), id);
     }
 
-    @DataProvider(name = "invalid longs")
+    @DataProvider(name = "invalid image IDs")
     public Object[][] invalidLongs() {
         return new Object[][] {
+            {"0"},
             {"not a number"},
-            {"0.1"}
+            {"0.1"},
+            {String.valueOf(-Integer.MAX_VALUE)}
         };
     }
 
     @Test(
-        dataProvider = "invalid longs",
+        dataProvider = "invalid image IDs",
         expectedExceptions = {IllegalArgumentException.class},
         expectedExceptionsMessageRegExp="Incorrect format for imageId parameter '.*'"
     )

--- a/src/test/java/com/glencoesoftware/omero/ms/core/OmeroRequestCtxTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/core/OmeroRequestCtxTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2025 Glencoe Software, Inc. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.glencoesoftware.omero.ms.core;
+
+import io.vertx.core.MultiMap;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class OmeroRequestCtxTest {
+
+    private MultiMap params = MultiMap.caseInsensitiveMultiMap();
+
+    @Test
+    public void testGetCheckedParams() {
+        params.add("imageId", "1");
+        params.add("key1", "value1");
+        params.add("key2", "value2");
+        Assert.assertEquals(OmeroRequestCtx.getCheckedParam(params, "imageId"), "1");
+        Assert.assertEquals(OmeroRequestCtx.getCheckedParam(params, "ImageID"), "1");
+        Assert.assertEquals(OmeroRequestCtx.getCheckedParam(params, "key1"), "value1");
+        Assert.assertEquals(OmeroRequestCtx.getCheckedParam(params, "key2"), "value2");
+    }
+
+    @Test(
+        expectedExceptions = {IllegalArgumentException.class},
+        expectedExceptionsMessageRegExp="Missing parameter '.*'"
+    )
+    public void testGetCheckedParamsMissingKey() {
+        OmeroRequestCtx.getCheckedParam(params, "missingkey");
+    }
+
+    @Test
+    public void testGetCheckedParamsMultipleValues() {
+        params.add("imageId", "1");
+        params.add("imageId", "2");
+        params.add("imageId", "3");
+        Assert.assertEquals(OmeroRequestCtx.getCheckedParam(params, "imageId"), "1");
+    }
+
+    @Test
+    public void testGetBooleanParameter() {
+        params.add("imageId", "1");
+        params.add("boolean1", "true");
+        params.add("boolean2", "false");
+        params.add("boolean3", "TRUE");
+        params.add("boolean4", "FALSE");
+        Assert.assertFalse(OmeroRequestCtx.getBooleanParameter(params, "imageId"));
+        Assert.assertTrue(OmeroRequestCtx.getBooleanParameter(params, "boolean1"));
+        Assert.assertFalse(OmeroRequestCtx.getBooleanParameter(params, "boolean2"));
+        Assert.assertTrue(OmeroRequestCtx.getBooleanParameter(params, "boolean3"));
+        Assert.assertFalse(OmeroRequestCtx.getBooleanParameter(params, "boolean4"));
+        Assert.assertFalse(OmeroRequestCtx.getBooleanParameter(params, "missingkey"));
+    }
+
+    @Test
+    public void testGetBooleanParameterMultipleValue() {
+        params.add("boolean1", "true");
+        params.add("boolean1", "false");
+        Assert.assertTrue(OmeroRequestCtx.getBooleanParameter(params, "boolean1"));
+    }
+
+    @DataProvider(name = "valid longs")
+    public Object[][] validLongs() {
+        return new Object[][] {
+            {"0", Long.valueOf(0)},
+            {"1", Long.valueOf(1)},
+            {String.valueOf(Integer.MAX_VALUE), Long.valueOf(Integer.MAX_VALUE)},
+            {String.valueOf(-Integer.MAX_VALUE), Long.valueOf(-Integer.MAX_VALUE)},
+            {String.valueOf(Long.MAX_VALUE), Long.valueOf(Long.MAX_VALUE)}
+        };
+    }
+
+    @Test(dataProvider = "valid longs")
+    public void testGetImageIdFromString(String value, Long id) {
+        Assert.assertEquals(OmeroRequestCtx.getImageIdFromString(value), id);
+    }
+
+    @DataProvider(name = "invalid longs")
+    public Object[][] invalidLongs() {
+        return new Object[][] {
+            {"not a number"},
+            {"0.1"}
+        };
+    }
+
+    @Test(
+        dataProvider = "invalid longs",
+        expectedExceptions = {IllegalArgumentException.class},
+        expectedExceptionsMessageRegExp="Incorrect format for imageId parameter '.*'"
+    )
+    public void testGetImageIdFromStringInvalid(String imageId) {
+        OmeroRequestCtx.getImageIdFromString(imageId);
+    }
+
+    @DataProvider(name = "valid integers")
+    public Object[][] validInts() {
+        return new Object[][] {
+            {"0", Integer.valueOf(0)},
+            {"1", Integer.valueOf(1)},
+            {String.valueOf(Integer.MAX_VALUE), Integer.valueOf(Integer.MAX_VALUE)},
+            {String.valueOf(-Integer.MAX_VALUE), Integer.valueOf(-Integer.MAX_VALUE)}
+        };
+    }
+
+    @Test(dataProvider = "valid integers")
+    public void testGetIntegerFromString(String value, Integer integer) {
+        Assert.assertEquals(OmeroRequestCtx.getIntegerFromString(value), integer);
+    }
+
+    @DataProvider(name = "invalid integers")
+    public Object[][] invalidInts() {
+        return new Object[][] {
+            {"not a number"},
+            {"0.1" },
+            {"0L"},
+            {String.valueOf(Long.valueOf(Integer.MAX_VALUE) + 1)}
+        };
+    }
+
+    @Test(
+        dataProvider = "invalid integers",
+        expectedExceptions = {IllegalArgumentException.class},
+        expectedExceptionsMessageRegExp="Incorrect format for parameter value '.*'"
+    )
+    public void testGetIntegerFromStringInvalid(String value) {
+        OmeroRequestCtx.getIntegerFromString(value);
+    }
+}


### PR DESCRIPTION
Fixes #26 

Given the planned release of `omero-ms-core` with the Vert.x 4 upgrade (#38), this is a good time to review whether the HTTP request parameters handling APIs introduced in https://github.com/glencoesoftware/omero-ms-image-region/pull/125 should be added to `OmeroRequestCtx`.

3b0fa9a7a7abbe5d70906e8a7c5bc0d6a355c366 copies the APIs without modification and adds some unit tests covering their functionality.

A few questions for the review:
- is the addition of these APIs still useful i.e. can we anticipate other `OmeroRequestCtx` subclass will take advantage of it?
- should the implementation `getImageIdFromString` only support positive longs?