### PR TITLE
Bump io.lettuce:lettuce-core from 5.2.0.RELEASE to 6.7.1.RELEASE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation 'io.zipkin.brave:brave:5.6.8'
     implementation 'io.zipkin.brave:brave-http:4.13.6'
     implementation 'io.zipkin.brave:brave-instrumentation-http:5.6.8'
-    implementation 'io.lettuce:lettuce-core:5.2.0.RELEASE'
+    implementation 'io.lettuce:lettuce-core:6.7.1.RELEASE'
     implementation 'org.openmicroscopy:omero-blitz:5.8.0'
     implementation 'io.vertx:vertx-web:3.8.1'
     implementation 'io.vertx:vertx-jdbc-client:3.8.1'


### PR DESCRIPTION
See https://redis.github.io/lettuce/new-features/ for a list of the changes associated with the last major and minor version increments In addition to a long overdue maintenance routine, the primary motivation for this change is to have support for ACL authentication introduced in Redis 6.x and available since the 6.0.0.RELEASE of lettuce-core

Note this upgrade incidentally upgrades some but not all of the `io.netty` transitive dependencies to `4.1.118.Final`. The `io.netty` dependencies not upgraded (`netty-codec-http`, `netty-codec-https2`, `netty-codec-socks`, `netty-handler-proxy`) are injected via `io.vertx:vertx-web:3.8.1`. This might need to be reviewed in the context of #38 