### PR TITLE
RedisCacheVerticle.stop: prevent NPE if the connection was never initialized

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/core/RedisCacheVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/core/RedisCacheVerticle.java
@@ -79,8 +79,10 @@ public class RedisCacheVerticle extends AbstractVerticle {
 
     @Override
     public void stop() {
-        connection.close();
-        client.shutdown();
+        if (connection != null) {
+          connection.close();
+          client.shutdown();
+        }
     }
 
     /**


### PR DESCRIPTION
Found while investigating https://github.com/glencoesoftware/omero-ms-core/pull/38#issuecomment-3001489015

Our default configuration for the image-region micro-service does not include a configuration for the `RedisCacheVerticle`  which is deployed on startup - see https://github.com/glencoesoftware/omero-ms-image-region/blob/3df9eb40284acaecf23e39bf32f8e7f303407df1/src/dist/conf/config.yaml#L73-L74. When stopping the micro-service, the current implementation leads to a NPE of type

```
2025-06-26 09:56:35,745 [vert.x-eventloop-thread-20] ERROR i.vertx.core.impl.DeploymentManager - Undeploy failed
java.lang.NullPointerException: null
	at com.glencoesoftware.omero.ms.core.RedisCacheVerticle.stop(RedisCacheVerticle.java:82)
	at io.vertx.core.AbstractVerticle.stop(AbstractVerticle.java:120)
	at io.vertx.core.Verticle.stop(Verticle.java:86)
	at io.vertx.core.impl.DeploymentManager$DeploymentImpl.lambda$doUndeploy$6(DeploymentManager.java:731)
	at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:369)
	at io.vertx.core.impl.EventLoopContext.lambda$executeAsync$0(EventLoopContext.java:38)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:510)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:518)
	at io.netty.util.concurrent.SingleThreadEventExecutor$6.run(SingleThreadEventExecutor.java:1044)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

398cd62e892721697196f597d9889e7df8c85589 simply adds a check for the existence of an initialized connection before attempting to close it and shutdown the client (both objects are initialized in the same block)